### PR TITLE
HTTP_403_FORBIDDEN

### DIFF
--- a/rest_api/tests.py
+++ b/rest_api/tests.py
@@ -54,7 +54,7 @@ class ViewsTestCase(TestCase):
         """Test that the api has user authorization."""
         new_client = APIClient()
         res = new_client.get('/bucketlists/', kwargs={'pk': 3}, format="json")
-        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_api_can_get_a_bucketlist(self):
         """Test the api can get a given bucketlist."""


### PR DESCRIPTION
The `test_authorization_is_enforced` test should be return HTTP_403_FORBIDDEN.